### PR TITLE
Fix: Adjust server routing for Vercel rewrites

### DIFF
--- a/cyber-audit-platform/server/src/index.ts
+++ b/cyber-audit-platform/server/src/index.ts
@@ -20,9 +20,9 @@ const corsOptions: cors.CorsOptions = {
 app.use(cors(corsOptions));
 app.use(express.json());
 
-app.use('/api', apiRoutes);
+app.use(apiRoutes);
 
-app.get('/api/health', (req: Request, res: Response) => {
+app.get('/health', (req: Request, res: Response) => {
   res.status(200).json({ message: 'Server is running and healthy!' });
 });
 


### PR DESCRIPTION
The Vercel deployment was returning 404 errors for all API requests. This was caused by a mismatch between Vercel's rewrite rules and the Express server's route definitions.

The `vercel.json` configuration has a rewrite rule: `"source": "/api/(.*)", "destination": "/cyber-audit-platform/server/dist/index.js"`

This rule strips the `/api` prefix from the request path before forwarding it to the serverless function. For example, a request to `/api/vulnerabilities/summary` would be received by the Express app as `/vulnerabilities/summary`.

However, the Express app was still expecting the `/api` prefix in its routes (e.g., `app.use('/api', apiRoutes)`). This caused a routing mismatch and resulted in 404 errors.

This commit removes the `/api` prefix from the route definitions in `cyber-audit-platform/server/src/index.ts` to align them with the paths being passed by Vercel's rewrite rule. This resolves the 404 errors.